### PR TITLE
Changed the interval speed for the Tutorial Task timer.

### DIFF
--- a/src/main/java/pw/hwk/tutorial/util/TutorialTask.java
+++ b/src/main/java/pw/hwk/tutorial/util/TutorialTask.java
@@ -116,7 +116,7 @@ public class TutorialTask {
                     cancel();
                 }
             }
-        }.runTaskTimer(plugin, 0, speed);
+        }.runTaskTimer(plugin, 0, 20L * speed);
     }
 
     public String tACC(String message) {


### PR DESCRIPTION
10L is way too quick. The original way I had coded the timer, was that 20L is equivalent to 20 Ticks in minecraft, which is 1 second. Therefore, 20L * configured tutorial timer. Would be greater than 1 second, because In the Caching Method, and in the Tutorial creation when a player creates a tutorial, there was a method for checking that the timer could not be set below a specific number so that, the views did not change faster than 10 seconds. I have changed the delay that works for now, however not sure why it was removed to be a configurable setting when it already was.